### PR TITLE
.babelrc adjustment to enable async/await syntax

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,12 @@
 {
-    "presets": ["@parcel/babel-preset-env"]
+  "presets": [
+    [
+      "@parcel/babel-preset-env",
+      {
+        "targets": {
+          "browsers": ["last 3 Chrome versions"]
+        }
+      }
+    ]
+  ]
 }


### PR DESCRIPTION
Ik heb async code getest met deze aanpassing in de .babelrc en dan krijg ik de error (in Firefox bij mij) niet meer, dus zo zou het moeten werken.