### PR TITLE
Balbel plugin voor private methods toegevoegd

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,12 @@
 {
-    "presets": ["@parcel/babel-preset-env"]
+  "presets": [
+    [
+      "@parcel/babel-preset-env",
+      {
+        "targets": {
+          "browsers": ["last 3 Chrome versions"]
+        }
+      }
+    ]
+  ]
 }

--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,12 @@
 {
-    "presets": [
-      ["@babel/preset-env", {"targets": {"browsers": "last 1 Chrome versions"}}]
-    ],
-    "plugins": ["@babel/plugin-proposal-class-properties"]
+  "presets": [
+    [
+      "@babel/preset-env",
+      { "targets": { "browsers": "last 1 Chrome versions" } }
+    ]
+  ],
+  "plugins": [
+    "@babel/plugin-proposal-class-properties",
+    "@babel/plugin-proposal-private-methods"
+  ]
 }

--- a/.babelrc
+++ b/.babelrc
@@ -1,12 +1,9 @@
 {
   "presets": [
     [
-      "@parcel/babel-preset-env",
-      {
-        "targets": {
-          "browsers": ["last 3 Chrome versions"]
-        }
-      }
+      "@babel/preset-env",
+      { "targets": { "browsers": "last 1 Chrome versions" } }
     ]
-  ]
+  ],
+  "plugins": ["@babel/plugin-proposal-class-properties"]
 }


### PR DESCRIPTION
Ik wilde een nieuw project starten en kreeg de error "@parcel/transformer-babel: Class private methods are not enabled". Met deze plugin was het opgelost.